### PR TITLE
[main-jp to main] Changing the input parameter for StdAgGrid + Moving execution time to be a part of StdAgGrid

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21,6 +21,7 @@
         "papaparse": "^5.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.3.0",
         "react-tabs": "^6.0.2"
       },
       "devDependencies": {
@@ -4956,6 +4957,14 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
+      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -5640,20 +5649,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {

--- a/app/package.json
+++ b/app/package.json
@@ -27,6 +27,7 @@
     "papaparse": "^5.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.3.0",
     "react-tabs": "^6.0.2"
   },
   "devDependencies": {

--- a/app/src/App.css
+++ b/app/src/App.css
@@ -1,10 +1,21 @@
 #root {
   margin: 0 auto;
   text-align: center;
+  height: 100vh;
+}
+
+body.dark-mode {
+  background-color: #333;
+  color: white;
+}
+
+body {
+  background-color: white;
+  color: black;
 }
 
 .app-container {
-  position: 'relative';
+  position: "relative";
   margin: 0 auto;
   flex-direction: column;
   justify-content: center;
@@ -21,7 +32,7 @@
 }
 
 .loading {
-  /* font-size: 12px; */
+  font-size: 14px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -29,6 +40,7 @@
 
 .dot {
   animation: dot 1s infinite;
+  margin: 0 2px;
 }
 
 .dot:nth-child(1) {
@@ -43,8 +55,10 @@
   animation-delay: 0.6s;
 }
 
+.table-tab {
+  outline: none;
+}
 @keyframes dot {
-
   0%,
   20%,
   100% {
@@ -95,9 +109,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  height:80vh;
+  height: 80vh;
   width: 90vw;
   /* border: 3px solid green; */
   background-color: #3f3f3f;
 }
-

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -17,7 +17,7 @@ import InitUserTable, {
   InitParquetTable,
   InitS3ParquetTable,
 } from "./components/table/initTable";
-
+import { IoInvertMode } from "react-icons/io5";
 interface TabPanelProps {
   children?: React.ReactNode;
   index: number;
@@ -66,6 +66,7 @@ function CustomTabPanel(props: TabPanelProps) {
       id={`simple-tabpanel-${index}`}
       aria-labelledby={`simple-tab-${index}`}
       className={`tab-panel${value !== index ? "-hidden" : ""}`}
+      style={{ backgroundColor: "inherit" }}
       {...other}
     >
       {value === index && (
@@ -83,6 +84,7 @@ function App() {
   const loadingFailedFlag = useRef<JSX.Element | null>(null);
   const [tabData, setTabData] = useState<any[]>([]);
   const [value, setValue] = React.useState(1); // Initial state of the tabs
+  const [darkMode, setDarkMode] = useState<boolean>(true);
 
   /* 
     README: Init Steps
@@ -120,6 +122,15 @@ function App() {
   /* 
     ------------END OF USER EDITABLE AREA------------
   */
+
+  useEffect(() => {
+    const userPrefersDark =
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+    setDarkMode(userPrefersDark);
+  }, []);
+
   useEffect(() => {
     setReady(true);
   }, [loadingFailedFlag]);
@@ -129,16 +140,11 @@ function App() {
     const tabData = [
       {
         label: "Tab 1",
-        content: (
-          <StdAgGrid
-            columnDataType={userColumns}
-            setExecutionTime={setExecutionTime}
-          />
-        ),
+        content: <StdAgGrid columnDataType={userColumns} darkMode={darkMode} />,
       },
     ];
     setTabData(tabData);
-  }, [loadingFailedFlag]);
+  }, [loadingFailedFlag, darkMode]);
 
   // render Tabs Functions
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -156,30 +162,11 @@ function App() {
     const newIndex = tabData.length;
     const newTab = {
       label: `Tab ${newIndex + 1}`, // Tab starts at 1, 0 is the plus button
-      content: (
-        <StdAgGrid
-          columnDataType={userColumns}
-          setExecutionTime={setExecutionTime}
-        />
-      ),
+      content: <StdAgGrid columnDataType={userColumns} darkMode={darkMode} />,
     };
     setTabData([...tabData, newTab]);
     setValue(newIndex + 1);
   };
-
-  function renderExecutionTime() {
-    if (executionTime === 0) {
-      return (
-        <div className="loading">
-          <span className="dot">🟡</span>
-          <span className="dot">🟡</span>
-          <span className="dot">🟡</span>
-        </div>
-      );
-    } else {
-      return <div>Exec: {executionTime.toFixed(2)} ms</div>;
-    }
-  }
 
   function renderTabs() {
     return (
@@ -188,11 +175,23 @@ function App() {
         onChange={handleChange}
         aria-label="basic tabs example"
       >
-        <IconButton onClick={handleAddTab} aria-label="add tab">
-          <AddIcon />
+        <IconButton
+          onClick={handleAddTab}
+          aria-label="add tab"
+          style={{
+            height: "40px",
+            outline: "none",
+            marginTop: "5px",
+          }}
+        >
+          <AddIcon style={{ color: darkMode ? "white" : "gray" }} />
         </IconButton>
         {tabData.map((tab, index) => (
-          <Tab label={tab.label} {...a11yProps(index)} />
+          <Tab
+            style={{ outline: "none" }}
+            label={tab.label}
+            {...a11yProps(index)}
+          />
         ))}
       </Tabs>
     );
@@ -203,13 +202,17 @@ function App() {
       <CustomTabPanel
         value={value}
         index={index + 1} // Value starts at 1. 0 is the add button
-        height={"95%"}
+        height={"94%"}
         width={"95%"}
       >
         {tab.content}
       </CustomTabPanel>
     ));
   }
+
+  const toggleDarkMode = () => {
+    setDarkMode(!darkMode);
+  };
 
   return (
     <ThemeProvider theme={darkTheme}>
@@ -218,13 +221,28 @@ function App() {
           className="top-right"
           style={{ position: "absolute", top: "10px", right: "10px" }}
         >
-          {renderExecutionTime()}
+          <div style={{ fontSize: "25px", marginLeft: "30px", height: "40px" }}>
+            <IoInvertMode onClick={toggleDarkMode} />
+          </div>
         </div>
         <h1 className="app-title">Standard Grid</h1>
         <div>
           {ready ? (
-            <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-              <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+            <Box
+              sx={{
+                borderBottom: 1,
+                borderColor: "divider",
+                border: "1px solid gray",
+                borderRadius: "10px",
+                padding: "10px",
+              }}
+            >
+              <Box
+                sx={{
+                  borderBottom: 0.5,
+                  borderColor: darkMode ? "divider" : "gray",
+                }}
+              >
                 {renderTabs()}
               </Box>
               {renderTabPanels()}

--- a/app/src/components/grid/style.css
+++ b/app/src/components/grid/style.css
@@ -65,12 +65,29 @@
   background-color: rgb(120, 79, 191) !important;
 }
 
-.dark-mode {
+/* .dark-mode {
   background-color: #333;
   color: #fff;
-}
+} */
 
 .menu-button {
   width: 200px; /* or any other value */
   margin: 2px 0;
+}
+
+/* Light mode scrollbar */
+.ag-theme-alpine ::-webkit-scrollbar {
+  width: 12px;
+}
+
+.ag-theme-alpine ::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+.ag-theme-alpine ::-webkit-scrollbar-thumb {
+  background: #888;
+}
+
+.ag-theme-alpine ::-webkit-scrollbar-thumb:hover {
+  background: #555;
 }


### PR DESCRIPTION
From
<img width="1782" alt="Screenshot 2024-09-21 at 4 17 48 PM" src="https://github.com/user-attachments/assets/cff91e46-c98f-4fec-b23f-c3ba3f0c7dff">
to
<img width="1796" alt="Screenshot 2024-09-21 at 4 18 12 PM" src="https://github.com/user-attachments/assets/123c7887-c80d-4624-999c-92278a2d3851">

- Fix for the light mode
- Execution time to be shown for each duck grid
- Dark mode toggle placed outside of the component
- Dark mode as an optional input parameter to StdAgGrid (if null, detect the user's current mode)